### PR TITLE
chore: revert support for node12.x for backward compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "tailwindcss"
   ],
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 12.0.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,10 +65,17 @@ export function sortClasses(classStr: string, options: IOption = {}): string {
     const knownClassNamesWithOrder: (string | number)[][] = [];
 
     for (const className of parts) {
-        const order: number =
-            generateRules(new Set([className]), context).sort(([a], [z]) =>
-                bigSign(z - a)
-            )[0]?.[0] ?? null;
+        let order: number | null;
+
+        const ruleOrder = generateRules(new Set([className]), context).sort(
+            ([a], [z]) => bigSign(z - a)
+        )[0];
+
+        if (ruleOrder) {
+            order = ruleOrder[0];
+        } else {
+            order = null;
+        }
 
         if (order) {
             knownClassNamesWithOrder.push([className, order]);


### PR DESCRIPTION
This PR add support for node12.x for backward compatibility.
We plan to support node12.x up to EOL, but not after that.